### PR TITLE
Add prefix `com.attentivemobile.fork` to build artifacts

### DIFF
--- a/flink-connector-pulsar-e2e-tests/pom.xml
+++ b/flink-connector-pulsar-e2e-tests/pom.xml
@@ -21,7 +21,7 @@ under the License.
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<parent>
-		<groupId>org.apache.flink</groupId>
+		<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 		<artifactId>flink-connector-pulsar-parent</artifactId>
 		<version>3.0-SNAPSHOT</version>
 	</parent>
@@ -48,9 +48,9 @@ under the License.
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.flink</groupId>
+			<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 			<artifactId>flink-connector-pulsar</artifactId>
-			<version>${project.version}</version>
+			<version>3.0-SNAPSHOT</version>
 		</dependency>
 		<!-- pulsar-client-all requires jaxb-api for javax.xml.bind.annotation.XmlElement -->
 		<!-- packaged in flink-dist but not provided in e2e environment. -->
@@ -60,9 +60,9 @@ under the License.
 			<version>${jaxb-api.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.flink</groupId>
+			<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 			<artifactId>flink-connector-pulsar</artifactId>
-			<version>${project.version}</version>
+			<version>3.0-SNAPSHOT</version>
 			<type>test-jar</type>
 		</dependency>
 		<dependency>
@@ -163,7 +163,7 @@ under the License.
 							</outputDirectory>
 						</artifactItem>
 						<artifactItem>
-							<groupId>org.apache.flink</groupId>
+							<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 							<artifactId>flink-connector-pulsar</artifactId>
 							<version>${project.version}</version>
 							<destFileName>pulsar-connector.jar</destFileName>

--- a/flink-connector-pulsar-e2e-tests/pom.xml
+++ b/flink-connector-pulsar-e2e-tests/pom.xml
@@ -50,7 +50,7 @@ under the License.
 		<dependency>
 			<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 			<artifactId>flink-connector-pulsar</artifactId>
-			<version>3.0-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 		<!-- pulsar-client-all requires jaxb-api for javax.xml.bind.annotation.XmlElement -->
 		<!-- packaged in flink-dist but not provided in e2e environment. -->
@@ -62,7 +62,7 @@ under the License.
 		<dependency>
 			<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 			<artifactId>flink-connector-pulsar</artifactId>
-			<version>3.0-SNAPSHOT</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 		</dependency>
 		<dependency>

--- a/flink-connector-pulsar/pom.xml
+++ b/flink-connector-pulsar/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>org.apache.flink</groupId>
+		<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 		<artifactId>flink-connector-pulsar-parent</artifactId>
 		<version>3.0-SNAPSHOT</version>
 	</parent>

--- a/flink-sql-connector-pulsar/pom.xml
+++ b/flink-sql-connector-pulsar/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>org.apache.flink</groupId>
+		<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 		<artifactId>flink-connector-pulsar-parent</artifactId>
 		<version>3.0-SNAPSHOT</version>
 	</parent>
@@ -40,9 +40,9 @@ under the License.
 
 	<dependencies>
 		<dependency>
-			<groupId>org.apache.flink</groupId>
+			<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 			<artifactId>flink-connector-pulsar</artifactId>
-			<version>${project.version}</version>
+			<version>3.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/flink-sql-connector-pulsar/pom.xml
+++ b/flink-sql-connector-pulsar/pom.xml
@@ -42,7 +42,7 @@ under the License.
 		<dependency>
 			<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 			<artifactId>flink-connector-pulsar</artifactId>
-			<version>3.0-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ under the License.
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.apache.flink</groupId>
+    <groupId>com.attentivemobile.fork.org.apache.flink</groupId>
     <artifactId>flink-connector-pulsar-parent</artifactId>
     <version>3.0-SNAPSHOT</version>
     <name>Flink : Connectors : Pulsar : Parent</name>
@@ -684,8 +684,27 @@ under the License.
             </plugin>
 
             <plugin>
+                <!-- Sets a 'rootDir' system property that points to the root of the project.
+                     Child projects who want to use it must set the ${flink.parent.artifactId} property -->
                 <groupId>org.commonjava.maven.plugins</groupId>
                 <artifactId>directory-maven-plugin</artifactId>
+                <version>0.1</version>
+                <executions>
+                    <execution>
+                        <id>directories</id>
+                        <goals>
+                            <goal>directory-of</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <property>rootDir</property>
+                            <project>
+                                <groupId>com.attentivemobile.fork.org.apache.flink</groupId>
+                                <artifactId>${flink.parent.artifactId}</artifactId>
+                            </project>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Purpose of the change

* To build an Attentive-specific package that doesn't conflict with the open source package.

## Brief change log

Change the package `groupid` from `org.apache.flink` to `com.attentivemobile.fork.org.apache.flink`

It would be included like this in code 


```
<dependency>
    <groupId>com.attentivemobile.fork.org.apache.flink</groupId>
    <artifactId>flink-connector-pulsar</artifactId>
</dependency>

```
