### PR TITLE
Fix issue with the SourceUserCallback not being called as expected

### DIFF
--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/PulsarSourceReader.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/PulsarSourceReader.java
@@ -100,7 +100,7 @@ public class PulsarSourceReader<OUT>
         super(
                 elementsQueue,
                 fetcherManager,
-                new PulsarRecordEmitter<>(deserializationSchema),
+                new PulsarRecordEmitter<>(deserializationSchema, userCallback),
                 sourceConfiguration,
                 context);
 


### PR DESCRIPTION
With the changes pulled in to support newer versions of Flink there were non-trival adjustments to the code paths. This resulted in us losing the original callback hook and it wasn't being called.

This change makes the callback actually be called.