### PR TITLE
[STREAM-3294] fix: custom groupId for fork

### DIFF
--- a/flink-connector-pulsar-e2e-tests/pom.xml
+++ b/flink-connector-pulsar-e2e-tests/pom.xml
@@ -21,7 +21,7 @@ under the License.
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<parent>
-		<groupId>org.apache.flink</groupId>
+		<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 		<artifactId>flink-connector-pulsar-parent</artifactId>
 		<version>4.2-SNAPSHOT</version>
 	</parent>
@@ -36,12 +36,12 @@ under the License.
 
 	<dependencies>
 		<dependency>
-			<groupId>org.apache.flink</groupId>
+			<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 			<artifactId>flink-sql-connector-pulsar</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.flink</groupId>
+			<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 			<artifactId>flink-connector-pulsar</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
@@ -131,7 +131,7 @@ under the License.
 				<configuration>
 					<artifactItems>
 						<artifactItem>
-							<groupId>org.apache.flink</groupId>
+							<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 							<artifactId>flink-sql-connector-pulsar</artifactId>
 							<version>${project.version}</version>
 							<destFileName>pulsar-connector.jar</destFileName>

--- a/flink-connector-pulsar/pom.xml
+++ b/flink-connector-pulsar/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>org.apache.flink</groupId>
+		<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 		<artifactId>flink-connector-pulsar-parent</artifactId>
 		<version>4.2-SNAPSHOT</version>
 	</parent>

--- a/flink-sql-connector-pulsar/pom.xml
+++ b/flink-sql-connector-pulsar/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>org.apache.flink</groupId>
+		<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 		<artifactId>flink-connector-pulsar-parent</artifactId>
 		<version>4.2-SNAPSHOT</version>
 	</parent>
@@ -40,7 +40,7 @@ under the License.
 
 	<dependencies>
 		<dependency>
-			<groupId>org.apache.flink</groupId>
+			<groupId>com.attentivemobile.fork.org.apache.flink</groupId>
 			<artifactId>flink-connector-pulsar</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ under the License.
         <version>1.0.0</version>
     </parent>
 
-    <groupId>org.apache.flink</groupId>
+    <groupId>com.attentivemobile.fork.org.apache.flink</groupId>
     <artifactId>flink-connector-pulsar-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <name>Flink : Connectors : Pulsar : Parent</name>
@@ -554,6 +554,22 @@ under the License.
             <plugin>
                 <groupId>org.commonjava.maven.plugins</groupId>
                 <artifactId>directory-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>directories</id>
+                        <goals>
+                            <goal>directory-of</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <property>rootDir</property>
+                            <project>
+                                <groupId>com.attentivemobile.fork.org.apache.flink</groupId>
+                                <artifactId>${flink.parent.artifactId}</artifactId>
+                            </project>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Fix fork group id.

From `org.apache.flink` to `com.attentivemobile.fork.org.apache.flink`.